### PR TITLE
feat(nx-pwm): version-check executor

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,14 @@
     "default": {
       "runner": "@nrwl/nx-cloud",
       "options": {
-        "cacheableOperations": ["build", "lint", "test", "e2e", "depcheck"],
+        "cacheableOperations": [
+          "build",
+          "lint",
+          "test",
+          "e2e",
+          "depcheck",
+          "version-check"
+        ],
         "accessToken": "MjZlOGJhOWEtNThmNC00NzJmLWFmMzUtYjJhOWQyYjhmZDFifHJlYWQtd3JpdGU="
       }
     }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nrwl/nx-cloud": "14.0.5",
     "@nrwl/nx-plugin": "^14.1.9",
     "@nrwl/workspace": "14.1.9",
+    "@types/glob": "^7.2.0",
     "@types/jest": "27.4.1",
     "@types/node": "16.11.7",
     "@types/semver": "^7.3.9",

--- a/packages/nx-pwm/config-schema.json
+++ b/packages/nx-pwm/config-schema.json
@@ -22,6 +22,32 @@
           "required": ["discrepancies", "missing"]
         }
       }
+    },
+    "versionCheck": {
+      "type": "object",
+      "properties": {
+        "versionsFiles": {
+          "type": "object",
+          "properties": {
+            "versionsFilesGlob": {
+              "type": "string",
+              "default": "**/versions.ts"
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "excludeVariables": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {

--- a/packages/nx-pwm/executors.json
+++ b/packages/nx-pwm/executors.json
@@ -5,6 +5,11 @@
       "implementation": "./src/executors/depcheck/executor",
       "schema": "./src/executors/depcheck/schema.json",
       "description": "Runs a dependencies check on a project"
+    },
+    "version-check": {
+      "implementation": "./src/executors/version-check/executor",
+      "schema": "./src/executors/version-check/schema.json",
+      "description": "Performs checks on version of library versions supplied by a project"
     }
   }
 }

--- a/packages/nx-pwm/package.json
+++ b/packages/nx-pwm/package.json
@@ -17,8 +17,10 @@
   },
   "peerDependencies": {
     "@nrwl/devkit": "14.1.9",
-    "nx": "14.1.9",
+    "@nrwl/workspace": "14.1.9",
     "chalk": "^4.1.2",
+    "glob": "7.2.3",
+    "nx": "14.1.9",
     "semver": "^7.3.7"
   },
   "dependencies": {

--- a/packages/nx-pwm/project.json
+++ b/packages/nx-pwm/project.json
@@ -52,6 +52,9 @@
     "depcheck": {
       "executor": "nx-pwm:depcheck"
     },
+    "version-check": {
+      "executor": "nx-pwm:version-check"
+    },
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {

--- a/packages/nx-pwm/src/executors/version-check/executor.spec.ts
+++ b/packages/nx-pwm/src/executors/version-check/executor.spec.ts
@@ -1,0 +1,1 @@
+it.todo('executor tests are in e2e');

--- a/packages/nx-pwm/src/executors/version-check/executor.ts
+++ b/packages/nx-pwm/src/executors/version-check/executor.ts
@@ -1,0 +1,56 @@
+import { ExecutorContext } from '@nrwl/devkit';
+import { readNxPwmConfig } from '../../lib/config';
+import { NormalizedVersionCheckOptions } from '../../lib/version-check';
+import { performVersionsFileCheck } from './lib/perform-versions-file-check';
+import { VersionCheckExecutorSchema } from './schema';
+
+function normalizeScopes(scopes: string[]) {
+  return [
+    ...new Set([
+      'babel',
+      'emotion',
+      'reduxjs',
+      'swc',
+      'testing-library',
+      'types',
+      'nestjs',
+      'openapitools',
+      ...(scopes ?? []),
+    ]),
+  ];
+}
+
+export default async function runExecutor(
+  options: VersionCheckExecutorSchema,
+  { workspace, projectName }: ExecutorContext
+) {
+  const config = readNxPwmConfig();
+  const { root: projectRoot } = workspace.projects[projectName];
+
+  const normalizedConfig: NormalizedVersionCheckOptions = {
+    versionsFiles: {
+      ...config.versionCheck.versionsFiles,
+      excludeVariables:
+        config.versionCheck?.versionsFiles?.excludeVariables ?? [],
+      scopes: normalizeScopes(config.versionCheck?.versionsFiles?.scopes),
+    },
+  };
+
+  /**
+   * TODO:
+   * - add --fix option
+   * - add package.json check
+   */
+
+  let success = true;
+
+  if (options.checkVersionsFiles) {
+    success = await performVersionsFileCheck(
+      normalizedConfig,
+      projectRoot,
+      options
+    );
+  }
+
+  return { success };
+}

--- a/packages/nx-pwm/src/executors/version-check/executor.ts
+++ b/packages/nx-pwm/src/executors/version-check/executor.ts
@@ -1,7 +1,8 @@
 import { ExecutorContext } from '@nrwl/devkit';
 import { readNxPwmConfig } from '../../lib/config';
 import { NormalizedVersionCheckOptions } from '../../lib/version-check';
-import { performVersionsFileCheck } from './lib/perform-versions-file-check';
+import { performPackageJsonCheck } from './lib/perform-package-json-check';
+import { performVersionsFilesCheck } from './lib/perform-versions-files-check';
 import { VersionCheckExecutorSchema } from './schema';
 
 function normalizeScopes(scopes: string[]) {
@@ -29,28 +30,22 @@ export default async function runExecutor(
 
   const normalizedConfig: NormalizedVersionCheckOptions = {
     versionsFiles: {
-      ...config.versionCheck.versionsFiles,
+      ...config.versionCheck?.versionsFiles,
       excludeVariables:
         config.versionCheck?.versionsFiles?.excludeVariables ?? [],
       scopes: normalizeScopes(config.versionCheck?.versionsFiles?.scopes),
     },
   };
 
-  /**
-   * TODO:
-   * - add --fix option
-   * - add package.json check
-   */
+  const success = [
+    options.checkVersionsFiles
+      ? await performVersionsFilesCheck(normalizedConfig, projectRoot, options)
+      : true,
 
-  let success = true;
-
-  if (options.checkVersionsFiles) {
-    success = await performVersionsFileCheck(
-      normalizedConfig,
-      projectRoot,
-      options
-    );
-  }
+    options.checkPackageJson
+      ? await performPackageJsonCheck(projectRoot)
+      : true,
+  ].every((r) => r);
 
   return { success };
 }

--- a/packages/nx-pwm/src/executors/version-check/lib/logging.ts
+++ b/packages/nx-pwm/src/executors/version-check/lib/logging.ts
@@ -1,11 +1,6 @@
-import { logger } from '@nrwl/devkit';
+import { logger, output } from '@nrwl/devkit';
 import chalk from 'chalk';
-import { VersionComparisonResult } from '../../../lib/version-check/compare-package-version-to-latest';
-/**
- * chalk.bold(
-            comparison.package
-          )
- */
+import { VersionComparisonResult } from '../../../lib/version-check';
 
 export function logVersionComparisonResults<T extends VersionComparisonResult>(
   result: Record<string, T[]>,
@@ -27,26 +22,29 @@ export function logVersionComparisonResults<T extends VersionComparisonResult>(
       continue;
     }
 
-    for (const comparison of comparisons) {
+    const findings = comparisons.flatMap((comparison) => {
       if (comparison.outdated) {
-        console.log(
-          `${logContext} ⚠️ ${formatPackageName(
-            comparison
-          )} has new version ${chalk.bold(comparison.latest)} (current: ${
-            comparison.prev
-          })`
-        );
+        return [
+          `⚠️ ${formatPackageName(comparison)} has new version ${chalk.bold(
+            comparison.latest
+          )} (current: ${comparison.prev})`,
+        ];
       }
 
       if (comparison.invalid) {
-        console.log(
-          `${logContext} ❗ ${formatPackageName(
-            comparison
-          )} has an invalid version (${comparison.prev}) specified. Latest is ${
-            comparison.latest
-          }.`
-        );
+        return [
+          `❗ ${formatPackageName(comparison)} has an invalid version (${
+            comparison.prev
+          }) specified. Latest is ${comparison.latest}.`,
+        ];
       }
-    }
+
+      return [];
+    });
+
+    output.warn({
+      title: fileName,
+      bodyLines: findings,
+    });
   }
 }

--- a/packages/nx-pwm/src/executors/version-check/lib/logging.ts
+++ b/packages/nx-pwm/src/executors/version-check/lib/logging.ts
@@ -1,0 +1,52 @@
+import { logger } from '@nrwl/devkit';
+import chalk from 'chalk';
+import { VersionComparisonResult } from '../../../lib/version-check/compare-package-version-to-latest';
+/**
+ * chalk.bold(
+            comparison.package
+          )
+ */
+
+export function logVersionComparisonResults<T extends VersionComparisonResult>(
+  result: Record<string, T[]>,
+  formatPackageName: (comparison: T) => string
+) {
+  const maxFileNameLength = Math.max(
+    ...Object.keys(result).map((f) => f.length)
+  );
+
+  for (const [fileName, comparisons] of Object.entries(result)) {
+    const logContext = `${fileName.padEnd(maxFileNameLength)}`;
+
+    const hasInvalids = comparisons.filter(
+      (c) => c.invalid || c.outdated
+    ).length;
+
+    if (!hasInvalids) {
+      logger.info(`${logContext} ✅ All versions are up to date.`);
+      continue;
+    }
+
+    for (const comparison of comparisons) {
+      if (comparison.outdated) {
+        console.log(
+          `${logContext} ⚠️ ${formatPackageName(
+            comparison
+          )} has new version ${chalk.bold(comparison.latest)} (current: ${
+            comparison.prev
+          })`
+        );
+      }
+
+      if (comparison.invalid) {
+        console.log(
+          `${logContext} ❗ ${formatPackageName(
+            comparison
+          )} has an invalid version (${comparison.prev}) specified. Latest is ${
+            comparison.latest
+          }.`
+        );
+      }
+    }
+  }
+}

--- a/packages/nx-pwm/src/executors/version-check/lib/perform-package-json-check.ts
+++ b/packages/nx-pwm/src/executors/version-check/lib/perform-package-json-check.ts
@@ -1,0 +1,23 @@
+import { joinPathFragments, logger } from '@nrwl/devkit';
+import chalk from 'chalk';
+import { packageJsonCheck } from '../../../lib/version-check';
+import { logVersionComparisonResults } from './logging';
+
+export async function performPackageJsonCheck(projectRoot: string) {
+  const packageJsonPath = joinPathFragments(projectRoot, 'package.json');
+  const result = await packageJsonCheck(packageJsonPath);
+
+  const invalidComparisons = result.filter((c) => c.invalid || c.outdated);
+
+  if (!invalidComparisons.length) {
+    logger.info(`✅ All versions are up to date.`);
+    return true;
+  }
+
+  logVersionComparisonResults(
+    { [packageJsonPath]: result },
+    (c) => `${chalk.bold(c.package)}`
+  );
+
+  return false;
+}

--- a/packages/nx-pwm/src/executors/version-check/lib/perform-versions-file-check.ts
+++ b/packages/nx-pwm/src/executors/version-check/lib/perform-versions-file-check.ts
@@ -1,0 +1,48 @@
+import { logger, output } from '@nrwl/devkit';
+import chalk from 'chalk';
+import {
+  createOrUpdateMigrations,
+  NormalizedVersionCheckOptions,
+  versionsFilesCheck,
+} from '../../../lib/version-check';
+import { logVersionComparisonResults } from './logging';
+import { VersionCheckExecutorSchema } from '../schema';
+
+export async function performVersionsFileCheck(
+  normalizedConfig: NormalizedVersionCheckOptions,
+  projectRoot: string,
+  options: VersionCheckExecutorSchema
+) {
+  const result = await versionsFilesCheck(
+    normalizedConfig.versionsFiles,
+    projectRoot
+  );
+
+  const allComparisons = Object.values(result).flat();
+  const invalidComparisons = allComparisons.filter((c) => c.invalid);
+  const outdatedComparisons = allComparisons.filter((c) => c.outdated);
+
+  if (options.updateMigrations) {
+    if (outdatedComparisons.length) {
+      output.log({
+        title: 'Updating migrations.json',
+        bodyLines: [
+          'Migrations are created for outdated versions declared in versions files.',
+          `Migrations are placed in a placeholder update section ("version": "x.y.z"), update it to reflect the version you're going to release.`,
+        ],
+      });
+      createOrUpdateMigrations(projectRoot, outdatedComparisons);
+    } else {
+      logger.info(
+        'No outdated versions found, so not updating migrations.json'
+      );
+    }
+  }
+
+  logVersionComparisonResults(
+    result,
+    (c) => `${chalk.bold(c.package)} (${c.variable})`
+  );
+
+  return invalidComparisons.length > 0 || outdatedComparisons.length > 0;
+}

--- a/packages/nx-pwm/src/executors/version-check/schema.d.ts
+++ b/packages/nx-pwm/src/executors/version-check/schema.d.ts
@@ -1,0 +1,5 @@
+export interface VersionCheckExecutorSchema {
+  checkPackageJson: boolean;
+  checkVersionsFiles: boolean;
+  updateMigrations: boolean;
+}

--- a/packages/nx-pwm/src/executors/version-check/schema.d.ts
+++ b/packages/nx-pwm/src/executors/version-check/schema.d.ts
@@ -2,4 +2,5 @@ export interface VersionCheckExecutorSchema {
   checkPackageJson: boolean;
   checkVersionsFiles: boolean;
   updateMigrations: boolean;
+  updateVersionsFiles: boolean;
 }

--- a/packages/nx-pwm/src/executors/version-check/schema.json
+++ b/packages/nx-pwm/src/executors/version-check/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "cli": "nx",
+  "title": "VersionCheck executor",
+  "description": "",
+  "type": "object",
+  "properties": {
+    "checkPackageJson": {
+      "type": "boolean",
+      "description": "Check for versions to bump in package.json",
+      "default": true
+    },
+    "checkVersionsFiles": {
+      "type": "boolean",
+      "description": "Check for versions to bump in versions.ts files",
+      "default": true
+    },
+    "updateMigrations": {
+      "type": "boolean",
+      "description": "Create or update the migrations.json ",
+      "default": false
+    }
+  },
+  "required": []
+}

--- a/packages/nx-pwm/src/executors/version-check/schema.json
+++ b/packages/nx-pwm/src/executors/version-check/schema.json
@@ -17,7 +17,12 @@
     },
     "updateMigrations": {
       "type": "boolean",
-      "description": "Create or update the migrations.json ",
+      "description": "Create or update the migrations.json",
+      "default": false
+    },
+    "updateVersionsFiles": {
+      "type": "boolean",
+      "description": "Update checked versions files with newer versions",
       "default": false
     }
   },

--- a/packages/nx-pwm/src/lib/config.ts
+++ b/packages/nx-pwm/src/lib/config.ts
@@ -12,6 +12,13 @@ export interface NxPwmConfig {
       missing: IgnoreConfig;
     };
   };
+  versionCheck: {
+    versionsFiles: {
+      versionsFilesGlob: string;
+      scopes?: string[];
+      excludeVariables?: string[];
+    };
+  };
 }
 
 export const NX_PWM_CONFIG_PATH = '.nx-pwm.json';

--- a/packages/nx-pwm/src/lib/package-json.ts
+++ b/packages/nx-pwm/src/lib/package-json.ts
@@ -1,0 +1,15 @@
+import { PackageJson } from 'nx/src/utils/package-json';
+
+export interface PublishablePackageJson extends PackageJson {
+  publishConfig: {
+    access?: 'public' | 'restricted';
+    registry?: string;
+  };
+}
+
+export function isPublishablePackageJson(
+  json: unknown
+): json is PublishablePackageJson {
+  const publishConfig = (json as PublishablePackageJson)?.publishConfig;
+  return publishConfig && typeof publishConfig === 'object';
+}

--- a/packages/nx-pwm/src/lib/version-check/compare-package-version-to-latest.ts
+++ b/packages/nx-pwm/src/lib/version-check/compare-package-version-to-latest.ts
@@ -1,6 +1,6 @@
 import { logger } from '@nrwl/devkit';
 import { exec } from 'child_process';
-import { gt } from 'semver';
+import { gt, coerce } from 'semver';
 import { promisify } from 'util';
 
 const execAsync = promisify(exec);
@@ -18,6 +18,8 @@ export async function comparePackageVersionToLatest(
   version: string
 ): Promise<VersionComparisonResult> {
   try {
+    version = coerce(version).format();
+
     const output = await execAsync(`npm view ${pkg} version --json --silent`);
     const latest = JSON.parse(output.stdout);
 

--- a/packages/nx-pwm/src/lib/version-check/compare-package-version-to-latest.ts
+++ b/packages/nx-pwm/src/lib/version-check/compare-package-version-to-latest.ts
@@ -1,0 +1,56 @@
+import { logger } from '@nrwl/devkit';
+import { exec } from 'child_process';
+import { gt } from 'semver';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export interface VersionComparisonResult {
+  package: string;
+  outdated: boolean;
+  invalid: boolean;
+  latest: string;
+  prev?: string;
+}
+
+export async function comparePackageVersionToLatest(
+  pkg: string,
+  version: string
+): Promise<VersionComparisonResult> {
+  try {
+    const output = await execAsync(`npm view ${pkg} version --json --silent`);
+    const latest = JSON.parse(output.stdout);
+
+    if (gt(latest, version)) {
+      return {
+        package: pkg,
+        outdated: true,
+        invalid: false,
+        latest,
+        prev: version,
+      };
+    }
+    if (gt(version, latest)) {
+      return {
+        package: pkg,
+        outdated: false,
+        invalid: true,
+        latest,
+        prev: version,
+      };
+    }
+  } catch (e) {
+    // ignored
+    logger.error(
+      `Error parsing versions (${JSON.stringify({ pkg, version })})`
+    );
+    logger.error(e);
+  }
+
+  return {
+    package: pkg,
+    outdated: false,
+    invalid: false,
+    latest: version,
+  };
+}

--- a/packages/nx-pwm/src/lib/version-check/create-or-update-migrations.ts
+++ b/packages/nx-pwm/src/lib/version-check/create-or-update-migrations.ts
@@ -36,7 +36,8 @@ export function createOrUpdateMigrations(
 ) {
   const migrationsJsonPath = joinPathFragments(projectRoot, 'migrations.json');
   const migrations = readMigrationsJson(migrationsJsonPath);
-  const packageUpdates = migrations.packageJsonUpdates[versionPlaceholder];
+  const packageUpdates =
+    migrations.packageJsonUpdates[versionPlaceholder].packages;
 
   for (const comparison of comparisons) {
     if (comparison.outdated) {

--- a/packages/nx-pwm/src/lib/version-check/create-or-update-migrations.ts
+++ b/packages/nx-pwm/src/lib/version-check/create-or-update-migrations.ts
@@ -1,0 +1,51 @@
+import { joinPathFragments } from '@nrwl/devkit';
+import {
+  MigrationsJson,
+  PackageJsonUpdateForPackage,
+  PackageJsonUpdates,
+} from 'nx/src/config/misc-interfaces';
+import {
+  fileExists,
+  readJsonFile,
+  writeJsonFile,
+} from 'nx/src/utils/fileutils';
+import { VersionComparisonResult } from './compare-package-version-to-latest';
+
+const versionPlaceholder = 'x.y.z';
+const placeholderPackageJsonUpdate: PackageJsonUpdates = {
+  [versionPlaceholder]: { version: versionPlaceholder, packages: {} },
+};
+
+function readMigrationsJson(path: string): Omit<MigrationsJson, 'version'> {
+  if (!fileExists(path)) {
+    return {
+      packageJsonUpdates: placeholderPackageJsonUpdate,
+    };
+  }
+  const migrations = readJsonFile<MigrationsJson>(path);
+  migrations.packageJsonUpdates = {
+    ...placeholderPackageJsonUpdate,
+    ...migrations.packageJsonUpdates,
+  };
+  return migrations;
+}
+
+export function createOrUpdateMigrations(
+  projectRoot: string,
+  comparisons: VersionComparisonResult[]
+) {
+  const migrationsJsonPath = joinPathFragments(projectRoot, 'migrations.json');
+  const migrations = readMigrationsJson(migrationsJsonPath);
+  const packageUpdates = migrations.packageJsonUpdates[versionPlaceholder];
+
+  for (const comparison of comparisons) {
+    if (comparison.outdated) {
+      packageUpdates[comparison.package] = {
+        version: comparison.latest,
+        alwaysAddToPackageJson: false,
+      };
+    }
+  }
+
+  writeJsonFile(migrationsJsonPath, migrations);
+}

--- a/packages/nx-pwm/src/lib/version-check/index.ts
+++ b/packages/nx-pwm/src/lib/version-check/index.ts
@@ -1,0 +1,4 @@
+export * from './compare-package-version-to-latest';
+export * from './create-or-update-migrations';
+export * from './types';
+export * from './versions-files-check';

--- a/packages/nx-pwm/src/lib/version-check/index.ts
+++ b/packages/nx-pwm/src/lib/version-check/index.ts
@@ -1,4 +1,6 @@
 export * from './compare-package-version-to-latest';
 export * from './create-or-update-migrations';
+export * from './package-json-check';
 export * from './types';
+export * from './update-versions-file';
 export * from './versions-files-check';

--- a/packages/nx-pwm/src/lib/version-check/package-json-check.ts
+++ b/packages/nx-pwm/src/lib/version-check/package-json-check.ts
@@ -1,0 +1,77 @@
+import { readJsonFile, workspaceRoot } from '@nrwl/devkit';
+import chalk from 'chalk';
+import * as glob from 'glob';
+import { PackageJson } from 'nx/src/utils/package-json';
+import { relative } from 'path';
+import { nameToPackageJson } from '../workspace-utils';
+import { comparePackageVersionToLatest } from './compare-package-version-to-latest';
+
+try {
+  const files = glob
+    .sync('libs/**/package.json')
+    .map((x) => relative(workspaceRoot, x));
+  checkFiles(files);
+} catch (e) {
+  console.log(chalk.red(e.message));
+  process.exitCode = 1;
+}
+
+// -----------------------------------------------------------------------------
+
+async function checkFiles(packageJsonFiles: string[]) {
+  const rootPackageJson = readJsonFile<PackageJson>('package.json');
+
+  console.log(chalk.blue(`Checking versions in the following files...\n`));
+  console.log(`  - ${packageJsonFiles.join('\n  - ')}\n`);
+
+  const maxFileNameLength = Math.max(...packageJsonFiles.map((f) => f.length));
+
+  let hasError = false;
+
+  for (const f of packageJsonFiles) {
+    const packageJsonContent = readJsonFile<PackageJson>(f);
+
+    const results = await Promise.all(
+      Object.entries({
+        ...packageJsonContent.dependencies,
+        ...packageJsonContent.devDependencies,
+      })
+        .filter(([name]) => !nameToPackageJson[name])
+        .map<[name: string, version: string]>(([name, version]) => {
+          if (version !== '*') {
+            return [name, version];
+          }
+          const versionFromRoot: string =
+            rootPackageJson.dependencies?.[name] ??
+            rootPackageJson.devDependencies?.[name];
+
+          return [name, versionFromRoot];
+        })
+        .map(([pkg, version]) => comparePackageVersionToLatest(pkg, version))
+    );
+
+    const logContext = `${f.padEnd(maxFileNameLength)}`;
+
+    results.forEach((r) => {
+      if (r.outdated) {
+        console.log(
+          `${logContext} ⚠️ ${chalk.bold(
+            r.package
+          )} has new version ${chalk.bold(r.latest)} (current: ${r.prev})`
+        );
+      }
+      if (r.invalid) {
+        hasError = true;
+        console.log(
+          `${logContext} ❗ ${chalk.bold(r.package)} has an invalid version (${
+            r.prev
+          }) specified. Latest is ${r.latest}.`
+        );
+      }
+    });
+  }
+
+  if (hasError) {
+    throw new Error('Invalid versions of packages found (please see above).');
+  }
+}

--- a/packages/nx-pwm/src/lib/version-check/types.ts
+++ b/packages/nx-pwm/src/lib/version-check/types.ts
@@ -1,0 +1,10 @@
+import { NxPwmConfig } from '../config';
+
+export type NormalizedVersionCheckOptions = {
+  [K in keyof NxPwmConfig['versionCheck']]: Required<
+    NxPwmConfig['versionCheck'][K]
+  >;
+};
+
+export type VersionsFilesCheckConfig =
+  NormalizedVersionCheckOptions['versionsFiles'];

--- a/packages/nx-pwm/src/lib/version-check/update-versions-file.ts
+++ b/packages/nx-pwm/src/lib/version-check/update-versions-file.ts
@@ -1,0 +1,19 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { VariableVersionComparisonResult } from './versions-files-check';
+
+export function updateVersionsFile(
+  file: string,
+  outdatedDependencies: VariableVersionComparisonResult[]
+) {
+  let versionsContent = readFileSync(file).toString();
+
+  // TODO: update this with ts-morph or something else
+  for (const { variable, prev, latest } of outdatedDependencies) {
+    versionsContent = versionsContent.replace(
+      `${variable} = '${prev}'`,
+      `${variable} = '${latest}'`
+    );
+  }
+
+  writeFileSync(file, versionsContent);
+}

--- a/packages/nx-pwm/src/lib/version-check/versions-files-check.ts
+++ b/packages/nx-pwm/src/lib/version-check/versions-files-check.ts
@@ -1,20 +1,5 @@
-/*
- * This script checks if new versions of node modules are available.
- * It uses naming conventions to transform constants to matching node module name.
- *
- * Usage:
- *   yarn check-versions [file|package]
- *
- * Positional arg:
- *   - [file]: relative or absolute file path to the versions file.
- *
- * Example:
- *   yarn check-versions react
- */
-
 import { workspaceRoot } from '@nrwl/devkit';
 import { dasherize } from '@nrwl/workspace/src/utils/strings';
-import chalk from 'chalk';
 import * as glob from 'glob';
 import { relative } from 'path';
 import {
@@ -41,12 +26,7 @@ export async function versionsFilesCheck(
   return await checkFiles(config, versionFiles);
 }
 
-// -----------------------------------------------------------------------------
-
 async function checkFiles(config: VersionsFilesCheckConfig, files: string[]) {
-  console.log(chalk.blue(`Checking versions in the following files...\n`));
-  console.log(`  - ${files.join('\n  - ')}\n`);
-
   const results: Record<string, VariableVersionComparisonResult[]> =
     Object.fromEntries(
       await Promise.all(files.map(async (f) => [f, await checkFile(config, f)]))
@@ -59,11 +39,6 @@ async function checkFile(
   config: VersionsFilesCheckConfig,
   f: string
 ): Promise<VersionComparisonResult[]> {
-  // const migrationsPath = join(projectRoot, 'migrations.json');
-  // const migrationsJson = readJsonSync(migrationsPath, { throws: false }) ?? {
-  //   packageJsonUpdates: {},
-  // };
-  // let versionsContent = readFileSync(f).toString();
   const versions = getVersions(f);
   const npmPackages = getPackages(config, versions);
   const results = await Promise.all(
@@ -73,30 +48,6 @@ async function checkFile(
     }))
   );
   return results;
-  // const packageUpdates: Record<string, PackageJsonUpdateForPackage> = {};
-
-  // results.forEach((r) => {
-  //   if (r.outdated) {
-  //     versionsContent = versionsContent.replace(
-  //       `${r.variable} = '${r.prev}'`,
-  //       `${r.variable} = '${r.latest}'`
-  //     );
-  //     packageUpdates[r.package] = {
-  //       version: r.latest,
-  //       alwaysAddToPackageJson: false,
-  //     };
-  //   }
-  // });
-
-  // TODO: figure out how these migration things work in NX itself
-  // if (Object.keys(packageUpdates).length > 0) {
-  //   migrationsJson.packageJsonUpdates['x.y.z'] = {
-  //     version: 'x.y.z',
-  //     packages: packageUpdates,
-  //   };
-  //   writeFileSync(f, versionsContent);
-  //   writeJsonSync(migrationsPath, migrationsJson, { spaces: 2 });
-  // }
 }
 
 function getVersions(path: string) {

--- a/packages/nx-pwm/src/lib/version-check/versions-files-check.ts
+++ b/packages/nx-pwm/src/lib/version-check/versions-files-check.ts
@@ -1,0 +1,139 @@
+/*
+ * This script checks if new versions of node modules are available.
+ * It uses naming conventions to transform constants to matching node module name.
+ *
+ * Usage:
+ *   yarn check-versions [file|package]
+ *
+ * Positional arg:
+ *   - [file]: relative or absolute file path to the versions file.
+ *
+ * Example:
+ *   yarn check-versions react
+ */
+
+import { workspaceRoot } from '@nrwl/devkit';
+import { dasherize } from '@nrwl/workspace/src/utils/strings';
+import chalk from 'chalk';
+import * as glob from 'glob';
+import { relative } from 'path';
+import {
+  comparePackageVersionToLatest,
+  VersionComparisonResult,
+} from './compare-package-version-to-latest';
+import { VersionsFilesCheckConfig } from './types';
+
+export interface VariableVersionComparisonResult
+  extends VersionComparisonResult {
+  variable: string;
+}
+
+export async function versionsFilesCheck(
+  config: VersionsFilesCheckConfig,
+  projectRoot: string
+) {
+  const versionsFilesGlob = config.versionsFilesGlob || '**/versions.ts';
+
+  const versionFiles = glob
+    .sync(`${projectRoot}/${versionsFilesGlob}`)
+    .map((x) => relative(workspaceRoot, x));
+
+  return await checkFiles(config, versionFiles);
+}
+
+// -----------------------------------------------------------------------------
+
+async function checkFiles(config: VersionsFilesCheckConfig, files: string[]) {
+  console.log(chalk.blue(`Checking versions in the following files...\n`));
+  console.log(`  - ${files.join('\n  - ')}\n`);
+
+  const results: Record<string, VariableVersionComparisonResult[]> =
+    Object.fromEntries(
+      await Promise.all(files.map(async (f) => [f, await checkFile(config, f)]))
+    );
+
+  return results;
+}
+
+async function checkFile(
+  config: VersionsFilesCheckConfig,
+  f: string
+): Promise<VersionComparisonResult[]> {
+  // const migrationsPath = join(projectRoot, 'migrations.json');
+  // const migrationsJson = readJsonSync(migrationsPath, { throws: false }) ?? {
+  //   packageJsonUpdates: {},
+  // };
+  // let versionsContent = readFileSync(f).toString();
+  const versions = getVersions(f);
+  const npmPackages = getPackages(config, versions);
+  const results = await Promise.all(
+    npmPackages.map(async ({ variable, pkg, version }) => ({
+      variable,
+      ...(await comparePackageVersionToLatest(pkg, version)),
+    }))
+  );
+  return results;
+  // const packageUpdates: Record<string, PackageJsonUpdateForPackage> = {};
+
+  // results.forEach((r) => {
+  //   if (r.outdated) {
+  //     versionsContent = versionsContent.replace(
+  //       `${r.variable} = '${r.prev}'`,
+  //       `${r.variable} = '${r.latest}'`
+  //     );
+  //     packageUpdates[r.package] = {
+  //       version: r.latest,
+  //       alwaysAddToPackageJson: false,
+  //     };
+  //   }
+  // });
+
+  // TODO: figure out how these migration things work in NX itself
+  // if (Object.keys(packageUpdates).length > 0) {
+  //   migrationsJson.packageJsonUpdates['x.y.z'] = {
+  //     version: 'x.y.z',
+  //     packages: packageUpdates,
+  //   };
+  //   writeFileSync(f, versionsContent);
+  //   writeJsonSync(migrationsPath, migrationsJson, { spaces: 2 });
+  // }
+}
+
+function getVersions(path: string) {
+  try {
+    return require(path);
+  } catch {
+    throw new Error(`Could not load ${path}. Please make sure it is valid.`);
+  }
+}
+
+interface PackageInfo {
+  pkg: string;
+  version: string;
+  variable: string;
+}
+
+function getPackages(
+  { excludeVariables, scopes }: VersionsFilesCheckConfig,
+  versions: Record<string, string>
+) {
+  return Object.entries(versions).reduce((acc, [variable, version]) => {
+    if (!excludeVariables.includes(variable)) {
+      const pkg = getNpmName(scopes, variable);
+      acc.push({ pkg, version, variable });
+    }
+    return acc;
+  }, [] as PackageInfo[]);
+}
+
+function getNpmName(scopes: string[], name: string): string {
+  const dashedName = dasherize(name.replace(/Version$/, ''));
+  const scope = scopes.find((s) => dashedName.startsWith(`${s}-`));
+
+  if (scope) {
+    const rest = dashedName.split(`${scope}-`)[1];
+    return `@${scope}/${rest}`;
+  } else {
+    return dashedName;
+  }
+}

--- a/packages/nx-pwm/src/lib/workspace-utils.ts
+++ b/packages/nx-pwm/src/lib/workspace-utils.ts
@@ -1,0 +1,43 @@
+import {
+  joinPathFragments,
+  readJsonFile,
+  workspaceRoot,
+  Workspaces,
+} from '@nrwl/devkit';
+import { existsSync } from 'fs';
+import {
+  isPublishablePackageJson,
+  PublishablePackageJson,
+} from './package-json';
+
+export const workspace = new Workspaces(
+  workspaceRoot
+).readWorkspaceConfiguration();
+
+function packageJsonOfLib(path: string): PublishablePackageJson {
+  return existsSync(path) && readJsonFile(path);
+}
+
+export function outputPathForLib(lib: string) {
+  return workspace.projects[lib].targets.build.options.outputPath;
+}
+
+export const publishableProjects = Object.fromEntries(
+  Object.entries(workspace.projects)
+    .map(
+      ([name, config]) =>
+        [
+          name,
+          packageJsonOfLib(joinPathFragments(config.root, 'package.json')),
+        ] as const
+    )
+    .filter(([, packageJson]) => isPublishablePackageJson(packageJson))
+);
+
+export const nameToPackageJson = Object.fromEntries(
+  Object.values(publishableProjects).map((p) => [p.name, p])
+);
+
+export const namesOfPublishableLibraries = Object.values(
+  publishableProjects
+).map((p) => p.name);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,6 +1151,14 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/glob@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.2":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -1195,7 +1203,7 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/minimatch@^3.0.3":
+"@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==


### PR DESCRIPTION
`version-check` is a utility executor used for maintaining, and not necessarily as a gatekeeping command (like depcheck for example)

Checks include:
* versions files check for nx plugins
* package.json checks for all libraries

Also includes two code mods:
* updating outdated versions in versions files 
* upserting a placeholder migration in `migrations.json` for outdated versions