### PR TITLE
feat(nx-pwm): add option to accept wildcard version in depcheck discrepancies check

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+yarn documentation

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "scripts": {
     "commit": "git-cz",
+    "documentation": "yarn ts-node -P tools/tsconfig.tools.json tools/generate-executor-readme.ts",
     "prepare": "husky install"
   },
   "private": true,

--- a/packages/nx-pwm/config-schema.json
+++ b/packages/nx-pwm/config-schema.json
@@ -23,8 +23,13 @@
             }
           },
           "required": ["discrepancies", "missing"]
+        },
+        "acceptWildcardVersion": {
+          "type": "boolean",
+          "default": false
         }
-      }
+      },
+      "required": ["ignore"]
     },
     "versionCheck": {
       "type": "object",

--- a/packages/nx-pwm/src/executors/depcheck/hasher.ts
+++ b/packages/nx-pwm/src/executors/depcheck/hasher.ts
@@ -26,6 +26,7 @@ function hashNxPwmConfigDepcheckSectionForProject(
       ...missingForProject,
       ...discrepanciesForAll,
       ...discrepanciesForProject,
+      `${nxPwmConfig?.depcheck?.acceptWildcardVersion ?? false}`,
     ]),
     implicitDeps: {
       [NX_PWM_CONFIG_PATH]: context.hasher.hashFile(NX_PWM_CONFIG_PATH),

--- a/packages/nx-pwm/src/lib/config.ts
+++ b/packages/nx-pwm/src/lib/config.ts
@@ -12,6 +12,7 @@ export interface NxPwmConfig {
       discrepancies: IgnoreConfig;
       missing: IgnoreConfig;
     };
+    acceptWildcardVersion?: boolean;
   };
   versionCheck?: {
     versionsFiles?: {

--- a/tools/generate-executor-readme.ts
+++ b/tools/generate-executor-readme.ts
@@ -42,7 +42,10 @@ for (const [executorName, { schema: schemaPath }] of executors) {
       const { type, description } = property;
       str += `${NL}### \`${propertyName}\`${NL}${description}${NL}`;
 
-      const propertyRequired = !!schema.required?.includes(propertyName);
+      const propertyRequired = !!(schema.required as string[])?.includes(
+        propertyName
+      );
+
       const defaultValue =
         'default' in property ? `\`${property.default}\`` : '';
 


### PR DESCRIPTION
This is useful for when you have a build script that populates the dist package.json versions with
versions from the root package.json because otherwise, the `"*"` version does not satisfy a semver
version.